### PR TITLE
Filter the post status

### DIFF
--- a/class-sync.php
+++ b/class-sync.php
@@ -551,10 +551,11 @@ class SPTT_Sync extends SPTT_Plugin {
 		$post_type = $this->taxonomy_syncs_with( $taxonomy );
 		if ( ! $post_type )
 			return;
-	
+		
+		$post_status = apply_filters( 'sptt_post_status', 'publish', $term, $post_type, $post_id );
 		$post_data = array(
 			'post_name' => $term->slug,
-			'post_status' => 'publish',
+			'post_status' => $post_status,
 			'post_title' => $term->name,
 			'post_type' => $post_type,
 		);


### PR DESCRIPTION
When creating a new post as part of a sync operation, allow the post status to be altered rather than using 'publish' every time.

There may be other areas where this filter - or similar - should be added, but I've not had a need for that yet ;)
